### PR TITLE
fix: stop page error when playing certain audio

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -247,8 +247,19 @@ const Currently = async () => {
   const filter = new Filter();
 
   const recent = song.is_playing ? song.item : song.items[0].track;
+
+  if (!recent) return (
+    <>
+      <p>
+        Listening to a podcast or something else.
+      </p>
+    </>
+  )
+
+  const isLatin = (text: string) => /^[\u0000-\u007F]*$/.test(text);
+  
   const track = {
-    title: filter.clean(recent.name),
+    title: isLatin(recent.name) ? filter.clean(recent.name || '') : recent.name || '',
     artist: recent.artists
       .map((_artist: { name: string }) => _artist.name)
       .shift(),


### PR DESCRIPTION
- check if song name contains non-latin text, if so, skip filtering to prevent page error:

Unhandled Runtime Error
Error: Cannot read properties of null (reading '0')

Source
app/page.tsx (190:18) @ clean

  188 | const recent = song.is_playing ? song.item : song.items[0].track;
  189 | const track = {
> 190 |   title: filter.clean(recent.name),
      |                ^
  191 |   artist: recent.artists
  192 |     .map((_artist: { name: string }) => _artist.name)
  193 |     .shift(),

- if playing podcast/audiobook, recent returns null, return placeholder to stop page error.