### PR TITLE
Fix homepage crash on Spotify error responses

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+export default function GlobalError({ reset }: { reset: () => void }) {
+  return (
+    <html lang="en">
+      <body className="flex flex-col items-start gap-y-2 p-8">
+        <p>something broke on my end.</p>
+        <button
+          onClick={reset}
+          className="underline cursor-pointer w-fit"
+          type="button"
+        >
+          try again
+        </button>
+      </body>
+    </html>
+  );
+}

--- a/components/now-playing-client.tsx
+++ b/components/now-playing-client.tsx
@@ -17,9 +17,9 @@ export default function NowPlayingClient({ initial }: { initial: any }) {
   if (!data) return null;
   const song = data?.data || initial;
 
-  const recent = song.is_playing ? song.item : song.items[0].track;
+  const recent = song?.is_playing ? song.item : song?.items?.[0]?.track;
 
-  if (!recent)
+  if (!recent?.album?.images?.[0]?.url)
     return (
       <div className="h-16 w-full">
         im probably being rate limited by spotify if u see this
@@ -29,11 +29,11 @@ export default function NowPlayingClient({ initial }: { initial: any }) {
   const filter = new Filter();
 
   const track = {
-    title: filter.clean(recent.name),
-    artist: recent.artists
+    title: filter.clean(recent.name ?? ""),
+    artist: (recent.artists ?? [])
       .map((_artist: { name: string }) => _artist.name)
       .shift(),
-    songUrl: recent.external_urls.spotify,
+    songUrl: recent.external_urls?.spotify,
     coverArt: recent.album.images[0].url,
     previewUrl: recent.preview_url,
   };

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -35,7 +35,9 @@ const fetchSpotifyData = async (endpoint: string) => {
     },
   });
 
-  if (response.status === 204) {
+  // 204 = nothing playing, non-2xx = rate limited / expired token. Both return
+  // an error body we must not pass along as if it were track data.
+  if (response.status === 204 || !response.ok) {
     return {
       status: response.status,
     };
@@ -51,7 +53,7 @@ const fetchSpotifyData = async (endpoint: string) => {
 
 export const getSpotifyData = async () => {
   const nowPlaying = await fetchSpotifyData(NOW_PLAYING_ENDPOINT);
-  if (nowPlaying.status === 200 && nowPlaying.data.is_playing) {
+  if (nowPlaying.status === 200 && nowPlaying.data?.is_playing) {
     return {
       type: "now-playing",
       data: nowPlaying.data,


### PR DESCRIPTION
When Spotify rate-limited (429) or the token expired (401), fetchSpotifyData parsed the error body and returned it as `data`. That object is truthy but has no `is_playing` or `items`, so it passed the `if (!data)` check and then threw on `song.items[0]` during SSR of `/`:

  TypeError: Cannot read properties of undefined (reading '0')

The existing "rate limited by spotify" fallback was written for this case but sat one line below the throw, so it never fired. With `"use cache"` on MusicPlayer, one bad response took down the homepage for the full cache window.

- lib/spotify.ts: treat non-2xx like 204 and return no data, so error bodies never reach the client as track data
- lib/spotify.ts: optional-chain nowPlaying.data.is_playing
- now-playing-client.tsx: optional-chain the track derivation and gate on the cover URL that <Image> needs, so empty items[] or a partial payload renders the fallback instead of crashing
- app/global-error.tsx: add the missing error boundary that caused the secondary "Failed to load static file for page: /500 ENOENT"